### PR TITLE
[FIX] -  Leitura do documento carregando mais de uma vez

### DIFF
--- a/src/embedded.js
+++ b/src/embedded.js
@@ -6,6 +6,10 @@ function Clicksign(key) {
       origin = window.location.protocol + '//' + window.location.host,
       listen = {};
 
+  var handle = function (ev) {
+    trigger(ev.data);
+  };
+
   var mount = function (id) {
     var path = '/sign/' + key,
         params = '?embedded=true&origin=' + this.origin,
@@ -34,10 +38,6 @@ function Clicksign(key) {
 
   var trigger = function (ev) {
     (listen[eventName(ev)] || []).forEach(function(fn) { fn(ev.data); });
-  };
-
-  var handle = function (ev) {
-    trigger(ev.data);
   };
 
   var unmount = function () {


### PR DESCRIPTION
### Descrição

A função `unmount` não está removendo os eventos corretamente.

Olhando o arquivo compilado o evento setado para o window message não é o mesmo ao realizar o `unmount()`.

Para a correção alteramos a ordem de declaração da função `handle()`, para que a referencia na hora da compilação seja a mesma para adição do `addEventlistener` e `removeEventListener`.

O problema foi observado dentro de um fluxo de steps, onde era carregado os eventos do clicksign em um dos steps, se o usuário precisava voltar para um step anterior ao do clicksign por algum motivo, e depois quisesse seguir em frente com os steps, os eventos era carregado mais de uma vez, e com isso no momento de assinar o documento era feito múltiplas requisições.  

### Issue tracker

\[Link para o card no Kanbanize.\]

### Screenshots (para mudanças de UI, se houver)
Observar o `window.addEventListener` das linhas 27 e 30

Print: build do código não alterado
![image](https://user-images.githubusercontent.com/13186981/154554009-692f2080-02e9-4925-8a4e-8a6839c595eb.png)

Print: build do código alterado
![image](https://user-images.githubusercontent.com/13186981/154553514-6abc58de-fbe0-41a0-87ae-dc327a202a94.png)

### Links e observações

\[Links úteis que podem contextualizar e ajudar o revisor, por exemplo para a página de uma dependência que escolheu adicionar, ou um código que se inspirou, ou documentação externa (docs de uma API, do Vue, do Rails, etc).\]

### Checklist para poder mergear

- [ ] O código do PR inclui (ou já possui) testes para o código nele
- [ ] Os checks de linters estão passando
- [ ] Os checks de testes estão passando
